### PR TITLE
Added usage message when script is called without any arguments.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,5 +1,5 @@
-4.0.1
------
+4.1
+---
 
 Added usage message when script is called without any arguments.
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,8 @@
+4.0.1
+-----
+
+Added usage message when script is called without any arguments.
+
 4.0
 ---
 

--- a/vr/cli.py
+++ b/vr/cli.py
@@ -356,7 +356,11 @@ def handle_command_line():
     args = parser.parse_args()
     jaraco.logging.setup(args, format='%(message)s')
     args.vr = models.Velociraptor(args.url, args.username)
-    args.action.run(args)
+    try:
+        args.action.run(args)
+    except AttributeError:
+        parser.print_usage()
+        parser.exit(1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Slightly improving UX.

Replacing:
```
$ vr.cli 
Traceback (most recent call last):
  File ".../bin/vr.cli", line 11, in <module>
    sys.exit(handle_command_line())
  File ".../lib/python/site-packages/vr/cli.py", line 359, in handle_command_line
    args.action.run(args)
AttributeError: 'Namespace' object has no attribute 'action'
```
with:
```
$ vr.cli
usage: vr.cli [-h] [--url URL] [--username USERNAME] [-l LOG_LEVEL]
              {list-swarms,procs,rebuild-all,build,compare-releases,swarm,deploy,uptests}
              ...
```